### PR TITLE
Archive template mutates the shared site.posts array

### DIFF
--- a/app/templates/archive.us
+++ b/app/templates/archive.us
@@ -6,7 +6,7 @@
   <section class="body">
     <div class="inner">
       <ul>
-      <% _(site.posts).chain().reverse().each(function(post){ %>
+      <% site.posts.slice().reverse().forEach(function(post){ %>
         <li>
           <a href="/<%= post.htmlPath() %>"><%= post.title() %></a>
         </li>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "lineman": "0.21.3",
-    "grunt-markdown-blog": "0.2.3",
+    "grunt-markdown-blog": "0.2.4",
     "underscore": "1.5.2"
   }
 }


### PR DESCRIPTION
The Archive template is mutating the site.posts array directly using .reverse(). (https://github.com/davemo/blog.davemo.com/blob/f6e8b014003c126a985d1cd4ed45e81a097da72c/app/templates/archive.us#L9)

The archive is the last file generated prior to the RSS feed. However, grunt-markdown-blog has a bug with the RSS feed such that it is only grabbing the X _oldest_ posts. (It's grabbing the first X posts in the ascending-sorted posts array). So, the bug with archive.us is actually masking the grunt-markdown-blog bug. :smile: 

grunt-markdown-blog v0.2.4 fixes this bug, so upgrading would expose the archive.us bug. (End result would be an rss feed only showing the very first 10 posts from 2008 or so.)
